### PR TITLE
dns srv outside ocp domain

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -29,7 +29,8 @@ data "template_file" "dns_userdata_dhcp" {
     hostname = "${var.dns.basename}${random_string.id.result}${count.index}"
     keyName = var.dns.bind.key_name
     secret = base64encode(var.ubuntu_password == null ? random_string.ubuntu_password.result : var.ubuntu_password)
-    domain = "${var.openshift_cluster_name}.${var.domain}"
+    domain = "${var.domain}"
+    ocpname = "${var.openshift_cluster_name}"
     openshift_api_ip = var.openshift_api_ip
     openshift_ingress_ip = var.openshift_ingress_ip
   }

--- a/userdata/dns_dhcp.userdata
+++ b/userdata/dns_dhcp.userdata
@@ -112,8 +112,8 @@ write_files:
                               NS      dns.${domain}.
       \$ORIGIN ${domain}.
       dns                     A       ip_to_be_replaced
-      api                     A       ${openshift_api_ip}
-      *                       A       ${openshift_ingress_ip}
+      api.${ocpname}          A       ${openshift_api_ip}
+      *.${ocpname}            A       ${openshift_ingress_ip}
       \$TTL 3600       ; 1 hour
       EOT
       sed -i -e "s/ip_to_be_replaced/$ip/g" /var/lib/bind/db.${domain}


### PR DESCRIPTION
dns server vm should be listed on the base domain and not inside the ocp cluster domain. needed for proper delegation and to accomodate multi ocp cluster deployment